### PR TITLE
Don't lose precision in get_fsound_tempo

### DIFF
--- a/it2fss.py
+++ b/it2fss.py
@@ -30,7 +30,7 @@ VALUE_NAMES = ['f', '8', '4', '2', '1']
 
 # Calculates and returns the fSound Speed based on the tempo and speed of an ImpulseTracker Module.
 def get_fsound_tempo(tempo: int, speed: int) -> int:
-    return 2500 // tempo * speed
+    return int(round(2500 / tempo * speed))
 
 
 # Sets current row values.


### PR DESCRIPTION
As agargara & damifortune mentioned in Discord, tempo conversion is currently a little off. Not losing precision in the tempo arithmetic for no reason (my fault, from the original code) is a good start toward fixing that.